### PR TITLE
Feature implementation from commits 72ec4e7..2f6694a

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,15 @@ COMP_EXECUTABLES = [
 ]
 ```
 
+### VCS Provider Specific Settings
+
+#### Github
+
+* ``GITHUB_OAUTH_TOKEN`` - Github oAuth token to use for authenticating against
+  the Github API. If not provided, it will default to unauthenticated API requests
+  which have low rate limits so an exception may be thrown when retrieving info
+  from the Github API due to the rate limit being reached.
+
 ## Getting help
 
 For help regarding the configuration of Codespeed, or to share any ideas or

--- a/codespeed/admin.py
+++ b/codespeed/admin.py
@@ -37,7 +37,7 @@ class ProjectAdmin(admin.ModelAdmin):
 
 @admin.register(Branch)
 class BranchAdmin(admin.ModelAdmin):
-    list_display = ('name', 'project')
+    list_display = ('name', 'project', 'display_on_comparison_page')
     list_filter = ('project',)
 
 

--- a/codespeed/commits/github.py
+++ b/codespeed/commits/github.py
@@ -19,6 +19,7 @@ import json
 
 import isodate
 from django.core.cache import cache
+from django.conf import settings
 
 from .exceptions import CommitLogError
 
@@ -91,11 +92,13 @@ def retrieve_revision(commit_id, username, project, revision=None):
     if revision:
         # Overwrite any existing data we might have for this revision since
         # we never want our records to be out of sync with the actual VCS:
-
-        # We need to convert the timezone-aware date to a naive (i.e.
-        # timezone-less) date in UTC to avoid killing MySQL:
-        revision.date = date.astimezone(
-            isodate.tzinfo.Utc()).replace(tzinfo=None)
+        if not getattr(settings, 'USE_TZ_AWARE_DATES', False):
+            # We need to convert the timezone-aware date to a naive (i.e.
+            # timezone-less) date in UTC to avoid killing MySQL:
+            logger.debug('USE_TZ_AWARE_DATES setting is set to False, '
+                         'converting datetime object to a naive one')
+            revision.date = date.astimezone(
+                isodate.tzinfo.Utc()).replace(tzinfo=None)
         revision.author = commit_json['author']['name']
         revision.message = commit_json['message']
         revision.full_clean()

--- a/codespeed/commits/github.py
+++ b/codespeed/commits/github.py
@@ -20,7 +20,6 @@ import re
 import json
 
 import isodate
-from django.conf import settings
 from django.core.cache import cache
 from django.conf import settings
 

--- a/codespeed/models.py
+++ b/codespeed/models.py
@@ -107,6 +107,9 @@ class Branch(models.Model):
     name = models.CharField(max_length=32)
     project = models.ForeignKey(
         Project, on_delete=models.CASCADE, related_name="branches")
+    display_on_comparison_page = models.BooleanField(
+        "True to display this branch in a list on the comparison page",
+        default=True)
 
     def __str__(self):
         return self.project.name + ":" + self.name

--- a/codespeed/settings.py
+++ b/codespeed/settings.py
@@ -83,3 +83,6 @@ USE_MEDIAN_BANDS = True # True to enable median bands on Timeline view
 
 ALLOW_ANONYMOUS_POST = True  # Whether anonymous users can post results
 REQUIRE_SECURE_AUTH = True  # Whether auth needs to be over a secure channel
+
+US_TZ_AWARE_DATES = False  # True to use timezone aware datetime objects with Github provider.
+                           # NOTE: Some database backends may not support tz aware dates.

--- a/codespeed/settings.py
+++ b/codespeed/settings.py
@@ -78,6 +78,13 @@ COMP_EXECUTABLES = None  # Which executable + revision should be checked as defa
                          #     ('myexe', '21df2423ra'),
                          #     ('myexe', 'L'),]
 
+TIMELINE_EXECUTABLE_NAME_MAX_LEN = 22  # Maximum length of the executable name used in the
+                                       # Changes and Timeline view. If the name is longer, the name
+                                       # will be truncated and "..." will be added at the end.
+
+COMPARISON_EXECUTABLE_NAME_MAX_LEN = 20  # Maximum length of the executable name  used in the
+                                         # Coomparison view. If the name is longer, the name
+
 USE_MEDIAN_BANDS = True # True to enable median bands on Timeline view
 
 

--- a/codespeed/tests/test_views_data.py
+++ b/codespeed/tests/test_views_data.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 from django.test import TestCase
+from django.test import override_settings
 
 from codespeed.models import Project, Executable, Branch, Revision
 from codespeed.views import getbaselineexecutables
+from codespeed.views_data import get_sanitized_executable_name_for_timeline_view
+from codespeed.views_data import get_sanitized_executable_name_for_comparison_view
 
 
 class TestGetBaselineExecutables(TestCase):
@@ -38,3 +41,25 @@ class TestGetBaselineExecutables(TestCase):
         Revision.objects.create(commitid='3', branch=self.branch)
         result = getbaselineexecutables()
         self.assertEqual(len(result), 3)
+
+
+class UtilityFunctionsTestCase(TestCase):
+    @override_settings(TIMELINE_EXECUTABLE_NAME_MAX_LEN=22)
+    def test_get_sanitized_executable_name_for_timeline_view(self):
+        executable = Executable(name='a' * 22)
+        name = get_sanitized_executable_name_for_timeline_view(executable)
+        self.assertEqual(name, 'a' * 22)
+
+        executable = Executable(name='a' * 25)
+        name = get_sanitized_executable_name_for_timeline_view(executable)
+        self.assertEqual(name, 'a' * 22 + '...')
+
+    @override_settings(COMPARISON_EXECUTABLE_NAME_MAX_LEN=20)
+    def test_get_sanitized_executable_name_for_comparision_view(self):
+        executable = Executable(name='b' * 20)
+        name = get_sanitized_executable_name_for_comparison_view(executable)
+        self.assertEqual(name, 'b' * 20)
+
+        executable = Executable(name='b' * 25)
+        name = get_sanitized_executable_name_for_comparison_view(executable)
+        self.assertEqual(name, 'b' * 20 + '...')

--- a/codespeed/views_data.py
+++ b/codespeed/views_data.py
@@ -120,7 +120,7 @@ def getcomparisonexes():
                 executables.append(exe)
 
         # add latest revs of the project
-        branches = Branch.objects.filter(project=proj)
+        branches = Branch.objects.filter(project=proj, display_on_comparison_page=True)
         for branch in branches:
             try:
                 rev = Revision.objects.filter(branch=branch).latest('date')

--- a/codespeed/views_data.py
+++ b/codespeed/views_data.py
@@ -58,13 +58,10 @@ def getbaselineexecutables():
     }]
     executables = Executable.objects.select_related('project')
     revs = Revision.objects.exclude(tag="").select_related('branch__project')
-    maxlen = getattr(settings, 'TIMELINE_EXECUTABLE_NAME_MAX_LEN', 20)
     for rev in revs:
         # Add executables that correspond to each tagged revision.
         for exe in [e for e in executables if e.project == rev.branch.project]:
-            exestring = str(exe)
-            if len(exestring) > maxlen:
-                exestring = str(exe)[0:maxlen] + "..."
+            exestring = get_sanitized_executable_name_for_timeline_view(exe)
             name = exestring + " " + rev.tag
             key = str(exe.id) + "+" + str(rev.id)
             baseline.append({
@@ -116,7 +113,6 @@ def getcomparisonexes():
     for proj in Project.objects.all():
         executables = []
         executablekeys = []
-        maxlen = getattr(settings, 'COMPARISON_EXECUTABLE_NAME_MAX_LEN', 20)
         # add all tagged revs for any project
         for exe in baselines:
             if exe['key'] != "none" and exe['executable'].project == proj:
@@ -134,9 +130,7 @@ def getcomparisonexes():
             # because we already added tagged revisions
             if rev.tag == "":
                 for exe in Executable.objects.filter(project=proj):
-                    exestring = str(exe)
-                    if len(exestring) > maxlen:
-                        exestring = str(exe)[0:maxlen] + "..."
+                    exestring = get_sanitized_executable_name_for_comparison_view(exe)
                     name = exestring + " latest"
                     if branch.name != 'default':
                         name += " in branch '" + branch.name + "'"
@@ -260,3 +254,47 @@ def get_stats_with_defaults(res):
     if res.q3 is not None:
         q3 = res.q3
     return q1, q3, val_max, val_min
+
+
+def get_sanitized_executable_name_for_timeline_view(executable):
+    """
+    Return sanitized executable name which is used in the sidebar in the
+    Timeline and Changes view.
+
+    If the name is longer than settings.TIMELINE_EXECUTABLE_NAME_MAX_LEN,
+    the name will be truncated to that length and "..." appended to it.
+
+    :param executable: Executable object.
+    :type executable: :class:``codespeed.models.Executable``
+
+    :return: ``str``
+    """
+    maxlen = getattr(settings, 'TIMELINE_EXECUTABLE_NAME_MAX_LEN', 20)
+
+    exestring = str(executable)
+    if len(exestring) > maxlen:
+        exestring = str(executable)[0:maxlen] + "..."
+
+    return exestring
+
+
+def get_sanitized_executable_name_for_comparison_view(executable):
+    """
+    Return sanitized executable name which is used in the sidebar in the
+    comparision view.
+
+    If the name is longer than settings.COMPARISON_EXECUTABLE_NAME_MAX_LEN,
+    the name will be truncated to that length and "..." appended to it.
+
+    :param executable: Executable object.
+    :type executable: :class:``codespeed.models.Executable``
+
+    :return: ``str``
+    """
+    maxlen = getattr(settings, 'COMPARISON_EXECUTABLE_NAME_MAX_LEN', 22)
+
+    exestring = str(executable)
+    if len(exestring) > maxlen:
+        exestring = str(executable)[0:maxlen] + "..."
+
+    return exestring

--- a/codespeed/views_data.py
+++ b/codespeed/views_data.py
@@ -58,7 +58,7 @@ def getbaselineexecutables():
     }]
     executables = Executable.objects.select_related('project')
     revs = Revision.objects.exclude(tag="").select_related('branch__project')
-    maxlen = 22
+    maxlen = getattr(settings, 'TIMELINE_EXECUTABLE_NAME_MAX_LEN', 20)
     for rev in revs:
         # Add executables that correspond to each tagged revision.
         for exe in [e for e in executables if e.project == rev.branch.project]:
@@ -116,7 +116,7 @@ def getcomparisonexes():
     for proj in Project.objects.all():
         executables = []
         executablekeys = []
-        maxlen = 20
+        maxlen = getattr(settings, 'COMPARISON_EXECUTABLE_NAME_MAX_LEN', 20)
         # add all tagged revs for any project
         for exe in baselines:
             if exe['key'] != "none" and exe['executable'].project == proj:


### PR DESCRIPTION
This PR contains changes from a range of commits from the original repository.

**Commit Range:** `72ec4e7..2f6694a`
**Files Changed:** 7 (6 programming files)
**Programming Ratio:** 85.7%

**Commits included:**
- Add new "display_on_comparison_page" field to the Branch model which
- Merge pull request #281 from Kami/make_maxlen_configurable
- Merge pull request #282 from Kami/add_provider_specific_settings_docs
- Merge pull request #279 from Kami/support_tz_aware_datetime_objects
- Add section on provider specific settings to the readme.
- Merge branch 'support_tz_aware_datetime_objects' of github.com:kami/codespeed into support_tz_aware_datetime_objects
- Fix lint issue.
- Merge branch 'master' of github.com:tobami/codespeed into support_tz_aware_datetime_objects
- Merge pull request #276 from Kami/fix_authentication_bug
- Move name truncating functionality in a utility function and add tests
... and 3 more commits